### PR TITLE
removed trailing slash from accessToken url

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -24,7 +24,7 @@ class Configuration extends \Nette\Object
      */
     public $url = array(
         'authorization' => 'https://www.linkedin.com/uas/oauth2/authorization',
-        'accessToken' => 'https://www.linkedin.com/uas/oauth2/accessToken/',
+        'accessToken' => 'https://www.linkedin.com/uas/oauth2/accessToken',
         'api' => 'https://api.linkedin.com/v1/'
     );
 


### PR DESCRIPTION
with the slash linkedin threw 404 error
